### PR TITLE
Add java[x] imports as separate group

### DIFF
--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -23,6 +23,9 @@
       <package name="" withSubpackages="true" static="true" />
       <emptyLine />
       <package name="" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="java" withSubpackages="true" static="false" />
+      <package name="javax" withSubpackages="true" static="false" />
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100" />


### PR DESCRIPTION
The STATIC###THIRD_PARTY_PACKAGE rule for customImportOrderRules and
the standardPackageRegExp mean that, previously, auto-formatting
IntelliJ imports would lead to Checkstyle failing, as the standard
packages are not grouped separately from third-party and same package
imports.

This creates a new group for java.* and javax.* imports, such that
IntelliJ can auto-format them correctly and pass validation.